### PR TITLE
Implement backend foundation with services and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The project is split into a **FastAPI backend** and a **React + TypeScript front
 
 ### Backend
 - Exposes REST endpoints for expansions, card data and EV calculation.
-- Provides service layer stubs for Cardmarket API communication and EV computation.
+- Implements an HTTP client using the public YGOProDeck API for expansion and card data.
+- Includes an expected value utility that validates probability distributions.
 - Written in Python 3.11 with FastAPI.
 - Tests are executed with `pytest`.
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,18 +1,47 @@
+from typing import Dict, List
+
 from fastapi import APIRouter
+from pydantic import BaseModel
+
+from ..services.cardmarket import CardmarketClient
+from ..services.ev import calculate_ev
+
 
 router = APIRouter()
 
-@router.get("/expansions")
-async def list_expansions() -> dict:
-    """Placeholder endpoint returning available Yugioh expansions."""
-    return {"expansions": []}
+cardmarket_client = CardmarketClient()
 
-@router.get("/expansions/{expansion_id}/cards")
-async def list_cards(expansion_id: int) -> dict:
-    """Placeholder endpoint returning cards for an expansion."""
-    return {"expansion_id": expansion_id, "cards": []}
+
+@router.get("/expansions")
+async def list_expansions() -> Dict[str, List[str]]:
+    """Return available Yugioh expansions."""
+
+    expansions = await cardmarket_client.get_expansions()
+    return {"expansions": expansions}
+
+
+@router.get("/expansions/{expansion_name}/cards")
+async def list_cards(expansion_name: str) -> Dict[str, List[Dict[str, float]]]:
+    """Return card data for the requested expansion."""
+
+    cards = await cardmarket_client.get_cards(expansion_name)
+    return {"expansion": expansion_name, "cards": cards}
+
+
+class CardPrice(BaseModel):
+    name: str
+    price: float
+
+
+class EVRequest(BaseModel):
+    cards: List[CardPrice]
+    probabilities: Dict[str, float]
+
 
 @router.post("/ev")
-async def calculate_ev(ev_request: dict) -> dict:
-    """Placeholder endpoint for EV calculation."""
-    return {"ev": 0}
+async def calculate_ev_endpoint(ev_request: EVRequest) -> Dict[str, float]:
+    """Calculate expected value from card prices and probabilities."""
+
+    cards_payload = [card.dict() for card in ev_request.cards]
+    ev = calculate_ev(cards_payload, ev_request.probabilities)
+    return {"ev": ev}

--- a/backend/app/services/cardmarket.py
+++ b/backend/app/services/cardmarket.py
@@ -1,8 +1,67 @@
+"""HTTP client for retrieving expansion and card data.
+
+The real Cardmarket API requires authentication. For the initial
+implementation the client consumes the public YGOProDeck API which exposes
+similar endpoints for sets and card information.  This allows the backend to
+provide useful data without credentials while keeping the service layer
+compatible with a future Cardmarket integration.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+
 class CardmarketClient:
-    """Placeholder for Cardmarket API interactions."""
+    """Client wrapper around the YGOProDeck API."""
 
-    def get_expansions(self):
-        raise NotImplementedError
+    BASE_URL = "https://db.ygoprodeck.com/api/v7"
 
-    def get_cards(self, expansion_id: int):
-        raise NotImplementedError
+    def __init__(self, client: Optional[httpx.AsyncClient] = None) -> None:
+        self._client = client
+
+    async def get_expansions(self) -> List[str]:
+        """Return available expansion names.
+
+        Uses a provided ``httpx.AsyncClient`` if supplied, otherwise creates a
+        temporary client for the request.
+        """
+
+        if self._client:
+            response = await self._client.get(f"{self.BASE_URL}/cardsets.php")
+        else:  # pragma: no cover - simple network call
+            async with httpx.AsyncClient() as client:
+                response = await client.get(f"{self.BASE_URL}/cardsets.php")
+
+        response.raise_for_status()
+        data: List[Dict[str, Any]] = response.json()
+        return [entry["set_name"] for entry in data]
+
+    async def get_cards(self, expansion_name: str) -> List[Dict[str, Any]]:
+        """Return cards for a given expansion.
+
+        Each card includes its name and Cardmarket price if available.
+        """
+
+        if self._client:
+            response = await self._client.get(
+                f"{self.BASE_URL}/cardinfo.php", params={"set": expansion_name}
+            )
+        else:  # pragma: no cover - simple network call
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.BASE_URL}/cardinfo.php", params={"set": expansion_name}
+                )
+
+        response.raise_for_status()
+        payload: Dict[str, Any] = response.json()
+        cards: List[Dict[str, Any]] = []
+        for card in payload.get("data", []):
+            price_info = card.get("card_prices", [{}])[0]
+            cards.append(
+                {
+                    "name": card["name"],
+                    "price": float(price_info.get("cardmarket_price", 0.0)),
+                }
+            )
+        return cards

--- a/backend/app/services/ev.py
+++ b/backend/app/services/ev.py
@@ -1,3 +1,36 @@
-def calculate_ev(cards: list, probabilities: dict) -> float:
-    """Placeholder Expected Value calculation."""
-    return 0.0
+"""Utility for expected value calculations."""
+
+from math import isclose
+from typing import Dict, Iterable
+
+
+def calculate_ev(cards: Iterable[dict], probabilities: Dict[str, float]) -> float:
+    """Compute the expected value of drawing a card.
+
+    Parameters
+    ----------
+    cards:
+        Iterable of card dictionaries containing at least ``name`` and ``price``.
+    probabilities:
+        Mapping of card names to the probability of pulling that card.
+
+    Returns
+    -------
+    float
+        The expected monetary value of one draw.
+
+    Raises
+    ------
+    ValueError
+        If the provided probabilities do not sum to 1.
+    """
+
+    total_prob = sum(probabilities.values())
+    if not isclose(total_prob, 1.0, rel_tol=1e-9):
+        raise ValueError("Probabilities must sum to 1")
+
+    ev = 0.0
+    for card in cards:
+        price = float(card.get("price", 0.0))
+        ev += price * probabilities.get(card.get("name"), 0.0)
+    return ev

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the application package is importable during tests
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/backend/tests/test_cardmarket_client.py
+++ b/backend/tests/test_cardmarket_client.py
@@ -1,0 +1,45 @@
+import asyncio
+
+import httpx
+
+from app.services.cardmarket import CardmarketClient
+
+def test_get_expansions() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - executed in test
+        return httpx.Response(200, json=[{"set_name": "Test Set"}])
+
+    transport = httpx.MockTransport(handler)
+
+    async def run() -> list[str]:
+        async with httpx.AsyncClient(transport=transport) as client:
+            cm_client = CardmarketClient(client=client)
+            return await cm_client.get_expansions()
+
+    expansions = asyncio.run(run())
+    assert expansions == ["Test Set"]
+
+
+def test_get_cards() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - executed in test
+        assert request.url.params.get("set") == "Test Set"
+        data = {
+            "data": [
+                {"name": "Card A", "card_prices": [{"cardmarket_price": "1.5"}]},
+                {"name": "Card B", "card_prices": [{"cardmarket_price": "0"}]},
+            ]
+        }
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+
+    async def run() -> list[dict[str, float]]:
+        async with httpx.AsyncClient(transport=transport) as client:
+            cm_client = CardmarketClient(client=client)
+            return await cm_client.get_cards("Test Set")
+
+    cards = asyncio.run(run())
+
+    assert cards == [
+        {"name": "Card A", "price": 1.5},
+        {"name": "Card B", "price": 0.0},
+    ]

--- a/backend/tests/test_ev.py
+++ b/backend/tests/test_ev.py
@@ -1,0 +1,16 @@
+import pytest
+
+from app.services.ev import calculate_ev
+
+
+def test_calculate_ev() -> None:
+    cards = [{"name": "A", "price": 1.0}, {"name": "B", "price": 2.0}]
+    probabilities = {"A": 0.25, "B": 0.75}
+    assert calculate_ev(cards, probabilities) == pytest.approx(1.75)
+
+
+def test_calculate_ev_invalid_probabilities() -> None:
+    cards = [{"name": "A", "price": 1.0}]
+    probabilities = {"A": 0.2}
+    with pytest.raises(ValueError):
+        calculate_ev(cards, probabilities)

--- a/backend/tests/test_placeholder.py
+++ b/backend/tests/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True


### PR DESCRIPTION
## Summary
- implement Cardmarket client using YGOProDeck API
- add expected value utility with probability validation
- expose expansions, card listing and EV calculation endpoints
- add unit tests for EV and Cardmarket client

## Testing
- `cd backend && pip install -r requirements.txt`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4c24094188323af058baa4be5a9d4