### PR TITLE
Add API key management and Cardmarket pricing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ The project is split into a **FastAPI backend** and a **React + TypeScript front
 
 ### Backend
 - Exposes REST endpoints for expansions, card data and EV calculation.
-- Implements an HTTP client using the public YGOProDeck API for expansion and card data.
+- Uses the public YGOProDeck API for expansion and card names and the
+  authenticated Cardmarket API for live pricing.
+- Stores the Cardmarket API key in a local `.env` file which is excluded from
+  version control. The key can be supplied via the console with
+  `python -m app.cli --key <TOKEN>` or through the web UI form.
 - Includes an expected value utility that validates probability distributions.
 - Written in Python 3.11 with FastAPI.
 - Tests are executed with `pytest`.

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3,12 +3,15 @@ from typing import Dict, List
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from ..config import get_cardmarket_key, set_cardmarket_key
 from ..services.cardmarket import CardmarketClient
 from ..services.ev import calculate_ev
+from ..services.ygopro import YGOProClient
 
 
 router = APIRouter()
 
+ygopro_client = YGOProClient()
 cardmarket_client = CardmarketClient()
 
 
@@ -16,7 +19,7 @@ cardmarket_client = CardmarketClient()
 async def list_expansions() -> Dict[str, List[str]]:
     """Return available Yugioh expansions."""
 
-    expansions = await cardmarket_client.get_expansions()
+    expansions = await ygopro_client.get_expansions()
     return {"expansions": expansions}
 
 
@@ -24,7 +27,11 @@ async def list_expansions() -> Dict[str, List[str]]:
 async def list_cards(expansion_name: str) -> Dict[str, List[Dict[str, float]]]:
     """Return card data for the requested expansion."""
 
-    cards = await cardmarket_client.get_cards(expansion_name)
+    names = await ygopro_client.get_cards(expansion_name)
+    cards: List[Dict[str, float]] = []
+    for name in names:
+        price = await cardmarket_client.get_price(name)
+        cards.append({"name": name, "price": price})
     return {"expansion": expansion_name, "cards": cards}
 
 
@@ -45,3 +52,22 @@ async def calculate_ev_endpoint(ev_request: EVRequest) -> Dict[str, float]:
     cards_payload = [card.dict() for card in ev_request.cards]
     ev = calculate_ev(cards_payload, ev_request.probabilities)
     return {"ev": ev}
+
+
+class APIKeyPayload(BaseModel):
+    api_key: str
+
+
+@router.post("/apikey")
+async def set_api_key(payload: APIKeyPayload) -> Dict[str, str]:
+    """Store the Cardmarket API key on the server."""
+
+    set_cardmarket_key(payload.api_key)
+    return {"status": "stored"}
+
+
+@router.get("/apikey")
+async def get_api_key() -> Dict[str, bool]:
+    """Return whether a Cardmarket API key has been configured."""
+
+    return {"configured": get_cardmarket_key() is not None}

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,0 +1,22 @@
+"""Console helpers for managing API keys."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+
+from .config import set_cardmarket_key
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Configure API keys")
+    parser.add_argument("--key", help="Cardmarket API key")
+    args = parser.parse_args()
+
+    key = args.key or getpass.getpass("Cardmarket API key: ")
+    set_cardmarket_key(key)
+    print("Cardmarket API key stored.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,43 @@
+"""Utility helpers for configuration and API key management."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
+
+
+def _load_env() -> None:
+    if not ENV_PATH.exists():
+        return
+    for line in ENV_PATH.read_text().splitlines():
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key, value)
+
+
+_load_env()
+
+
+def get_cardmarket_key() -> Optional[str]:
+    """Return the configured Cardmarket API key if present."""
+
+    return os.getenv("CARDMARKET_API_KEY")
+
+
+def set_cardmarket_key(key: str) -> None:
+    """Persist the Cardmarket API key to the local ``.env`` file."""
+
+    lines: list[str] = []
+    if ENV_PATH.exists():
+        lines = [
+            line
+            for line in ENV_PATH.read_text().splitlines()
+            if not line.startswith("CARDMARKET_API_KEY=")
+        ]
+    lines.append(f"CARDMARKET_API_KEY={key}")
+    ENV_PATH.write_text("\n".join(lines) + "\n")
+    os.environ["CARDMARKET_API_KEY"] = key

--- a/backend/app/services/ygopro.py
+++ b/backend/app/services/ygopro.py
@@ -1,0 +1,55 @@
+"""HTTP client for retrieving expansion and card data.
+
+The real Cardmarket API requires authentication. For the initial
+implementation the client consumes the public YGOProDeck API which exposes
+similar endpoints for sets and card information.  This allows the backend to
+provide useful data without credentials while keeping the service layer
+compatible with a future Cardmarket integration.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+
+class YGOProClient:
+    """Client wrapper around the public YGOProDeck API."""
+
+    BASE_URL = "https://db.ygoprodeck.com/api/v7"
+
+    def __init__(self, client: Optional[httpx.AsyncClient] = None) -> None:
+        self._client = client
+
+    async def get_expansions(self) -> List[str]:
+        """Return available expansion names.
+
+        Uses a provided ``httpx.AsyncClient`` if supplied, otherwise creates a
+        temporary client for the request.
+        """
+
+        if self._client:
+            response = await self._client.get(f"{self.BASE_URL}/cardsets.php")
+        else:  # pragma: no cover - simple network call
+            async with httpx.AsyncClient() as client:
+                response = await client.get(f"{self.BASE_URL}/cardsets.php")
+
+        response.raise_for_status()
+        data: List[Dict[str, Any]] = response.json()
+        return [entry["set_name"] for entry in data]
+
+    async def get_cards(self, expansion_name: str) -> List[str]:
+        """Return card names for a given expansion."""
+
+        if self._client:
+            response = await self._client.get(
+                f"{self.BASE_URL}/cardinfo.php", params={"set": expansion_name}
+            )
+        else:  # pragma: no cover - simple network call
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.BASE_URL}/cardinfo.php", params={"set": expansion_name}
+                )
+
+        response.raise_for_status()
+        payload: Dict[str, Any] = response.json()
+        return [card["name"] for card in payload.get("data", [])]

--- a/backend/tests/test_ygopro_client.py
+++ b/backend/tests/test_ygopro_client.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import httpx
+
+from app.services.ygopro import YGOProClient
+
+def test_get_expansions() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - executed in test
+        return httpx.Response(200, json=[{"set_name": "Test Set"}])
+
+    transport = httpx.MockTransport(handler)
+
+    async def run() -> list[str]:
+        async with httpx.AsyncClient(transport=transport) as client:
+            yg_client = YGOProClient(client=client)
+            return await yg_client.get_expansions()
+
+    expansions = asyncio.run(run())
+    assert expansions == ["Test Set"]
+
+
+def test_get_cards() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - executed in test
+        assert request.url.params.get("set") == "Test Set"
+        data = {"data": [{"name": "Card A"}, {"name": "Card B"}]}
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+
+    async def run() -> list[str]:
+        async with httpx.AsyncClient(transport=transport) as client:
+            yg_client = YGOProClient(client=client)
+            return await yg_client.get_cards("Test Set")
+
+    cards = asyncio.run(run())
+
+    assert cards == ["Card A", "Card B"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 import ExpansionSelector from './components/ExpansionSelector'
 import CardList from './components/CardList'
 import EVCalculator from './components/EVCalculator'
+import ApiKeyForm from './components/ApiKeyForm'
 
 const App: React.FC = () => {
   return (
     <div className="app-container">
       <h1>Cardmarket Price Comparison</h1>
       {/* Placeholder components */}
+      <ApiKeyForm />
       <ExpansionSelector />
       <CardList />
       <EVCalculator />

--- a/frontend/src/components/ApiKeyForm.tsx
+++ b/frontend/src/components/ApiKeyForm.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react'
+
+interface ApiKeyFormProps {}
+
+const ApiKeyForm: React.FC<ApiKeyFormProps> = () => {
+  const [key, setKey] = useState('')
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await fetch('http://localhost:8000/apikey', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: key })
+    })
+    setKey('')
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <input
+        type="password"
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        placeholder="Cardmarket API key"
+      />
+      <button type="submit">Save</button>
+    </form>
+  )
+}
+
+export default ApiKeyForm


### PR DESCRIPTION
## Summary
- Fetch expansions from YGOProDeck and prices from Cardmarket API
- Store Cardmarket API key in local `.env` and set via console or web UI
- Add React form for configuring API key

## Testing
- `pytest`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c41c497083238f4cd61f16cbd31b