### PR TITLE
feat: add YGOPro pricing fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ The project runs the backend and frontend in Docker containers, so the host only
 3. **Clone this repository**
    - `git clone https://github.com/<your-user>/CardmarketPriceComparison.git` *(replace `<your-user>` with the GitHub user or organization name)*
    - `cd CardmarketPriceComparison`
-4. **Create the Cardmarket API key file**
+4. **(Optional) Create the Cardmarket API key file**
    - `echo "CARDMARKET_API_KEY=<YOUR_TOKEN>" > backend/.env`
+   - Without this file the app will fall back to pricing data from the public YGOProDeck API.
 5. **Build and start the containers**
    - `docker-compose build`
    - `docker-compose up`
@@ -43,8 +44,9 @@ The project runs the backend and frontend in Docker containers, so the host only
    - Install [Git for Windows](https://git-scm.com/download/win) if needed.
    - `git clone https://github.com/<your-user>/CardmarketPriceComparison.git` *(replace `<your-user>` with the GitHub user or organization name)*
    - `cd CardmarketPriceComparison`
-4. **Add the API key**
+4. **(Optional) Add the API key**
    - `echo CARDMARKET_API_KEY=<YOUR_TOKEN> > backend/.env`
+   - If omitted, pricing is sourced from the YGOProDeck API.
 5. **Build and start the stack**
    - `docker compose build`
    - `docker compose up`
@@ -73,8 +75,9 @@ The project is split into a **FastAPI backend** and a **React + TypeScript front
 
 ### Backend
 - Exposes REST endpoints for expansions, card data and EV calculation.
-- Uses the public YGOProDeck API for expansion and card names and the
-  authenticated Cardmarket API for live pricing.
+- Uses the public YGOProDeck API for expansion and card names. If a
+  Cardmarket API key is supplied, pricing is pulled from Cardmarket;
+  otherwise YGOProDeck pricing is used.
 - Stores the Cardmarket API key in a local `.env` file which is excluded from
   version control. The key can be supplied via the console with
   `python -m app.cli --key <TOKEN>` or through the web UI form.

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -12,7 +12,7 @@ from ..services.ygopro import YGOProClient
 router = APIRouter()
 
 ygopro_client = YGOProClient()
-cardmarket_client = CardmarketClient()
+cardmarket_client = CardmarketClient(ygopro_client=ygopro_client)
 
 
 @router.get("/expansions")

--- a/backend/tests/test_cardmarket_client.py
+++ b/backend/tests/test_cardmarket_client.py
@@ -3,6 +3,7 @@ import asyncio
 import httpx
 
 from app.services.cardmarket import CardmarketClient
+from app.services.ygopro import YGOProClient
 
 
 def test_get_price_includes_auth_header() -> None:
@@ -19,3 +20,21 @@ def test_get_price_includes_auth_header() -> None:
 
     price = asyncio.run(run())
     assert price == 2.5
+
+
+def test_get_price_without_key_uses_ygopro() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - executed in test
+        assert request.url.params.get("name") == "Dark Magician"
+        data = {"data": [{"card_prices": [{"cardmarket_price": "0.45"}]}]}
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+
+    async def run() -> float:
+        async with httpx.AsyncClient(transport=transport) as client:
+            yg_client = YGOProClient(client=client)
+            cm_client = CardmarketClient(ygopro_client=yg_client)
+            return await cm_client.get_price("Dark Magician")
+
+    price = asyncio.run(run())
+    assert price == 0.45

--- a/backend/tests/test_ygopro_client.py
+++ b/backend/tests/test_ygopro_client.py
@@ -35,3 +35,21 @@ def test_get_cards() -> None:
     cards = asyncio.run(run())
 
     assert cards == ["Card A", "Card B"]
+
+
+def test_get_price() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - executed in test
+        assert request.url.params.get("name") == "Blue-Eyes"
+        data = {"data": [{"card_prices": [{"cardmarket_price": "1.23"}]}]}
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+
+    async def run() -> float:
+        async with httpx.AsyncClient(transport=transport) as client:
+            yg_client = YGOProClient(client=client)
+            return await yg_client.get_price("Blue-Eyes")
+
+    price = asyncio.run(run())
+
+    assert price == 1.23


### PR DESCRIPTION
## Summary
- fall back to YGOProDeck pricing when no Cardmarket API key is configured
- expose new `YGOProClient.get_price` helper
- document optional API key setup

## Testing
- `pytest`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c83d3cac8323956fb428ebf4e6d0