### PR TITLE
feat: log startup and change default ports

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -4,4 +4,5 @@ WORKDIR /app
 COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY backend /app/backend
-CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 8100
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8100"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -8,4 +8,4 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["sh", "-c", "echo 'Frontend running on http://localhost:3100' && nginx -g 'daemon off;'"]

--- a/README.md
+++ b/README.md
@@ -23,14 +23,17 @@ The project runs the backend and frontend in Docker containers, so the host only
 5. **Build and start the containers**
    - `docker-compose build`
    - `docker-compose up`
+   - When the services start you should see:
+     - `Backend API running on http://localhost:8100`
+     - `Frontend running on http://localhost:3100`
 6. **Visit the app**
-   - Frontend: `http://localhost:3000`
-   - Backend API: `http://localhost:8000`
+   - Frontend: `http://localhost:3100`
+   - Backend API: `http://localhost:8100`
 
 #### Troubleshooting
 - *Docker command not found*: ensure Docker is installed and the service is running (`sudo systemctl status docker`).
 - *Permission denied while connecting to Docker daemon*: run step 2 and re-login.
-- *Ports 3000 or 8000 already in use*: stop the conflicting service or edit `docker-compose.yml` to change the ports.
+- *Ports 3100 or 8100 already in use*: stop the conflicting service or edit `docker-compose.yml` to change the ports.
 
 ### Windows (Docker Desktop)
 
@@ -54,16 +57,18 @@ The project runs the backend and frontend in Docker containers, so the host only
    - From PowerShell in the project directory run:
      - `docker compose build`
      - `docker compose up`
+     - After the command prints `Backend API running on http://localhost:8100` and
+       `Frontend running on http://localhost:3100`, the services are ready.
 6. **Access the services**
-   - Frontend: <http://localhost:3000>
-   - Backend API: <http://localhost:8000>
+   - Frontend: <http://localhost:3100>
+   - Backend API: <http://localhost:8100>
 
 #### Troubleshooting
 - *Docker fails to start*: verify virtualization and WSL 2 are enabled; run `wsl --update` if the engine refuses to start.
 - *`git` or `docker` not recognized*: reopen PowerShell or use the terminal built into Docker Desktop.
 - *`docker compose` errors*: ensure you are inside the project folder and that you used `docker compose` (with a space), not the legacy `docker-compose`.
 - *File sharing or path errors*: keep the project inside your user directory (`C:\Users\<you>`) so Docker Desktop can mount it.
-- *Port 3000 or 8000 already in use*: stop the conflicting process or edit the `ports` in `docker-compose.yml`.
+- *Port 3100 or 8100 already in use*: stop the conflicting process or edit the `ports` in `docker-compose.yml`.
 - *Containers fail to build on Windows*: disable automatic line ending conversion with `git config core.autocrlf false` and clone again.
 
 
@@ -98,8 +103,8 @@ The project is split into a **FastAPI backend** and a **React + TypeScript front
 - Future analytics views can be added under `src/components`.
 
 ### Docker
-- `Dockerfile.backend` builds the FastAPI service and runs it with Uvicorn on port `8000`.
-- `Dockerfile.frontend` builds the React application and serves the static bundle through Nginx on port `3000`.
+- `Dockerfile.backend` builds the FastAPI service and runs it with Uvicorn on port `8100`.
+- `Dockerfile.frontend` builds the React application and serves the static bundle through Nginx on port `3100`.
 - `docker-compose.yml` wires both services together for local development.
 
 ## Development
@@ -124,7 +129,7 @@ docker-compose build
 docker-compose up
 ```
 
-The frontend will be available at `http://localhost:3000` and the backend API at `http://localhost:8000`.
+The frontend will be available at `http://localhost:3100` and the backend API at `http://localhost:8100`.
 
 ## License
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,16 @@
 from fastapi import FastAPI
 from .api.routes import router as api_router
+import logging
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Cardmarket Price Comparison API")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    """Log a message when the backend starts."""
+    logger.info("Backend API running on http://localhost:8100")
+
 
 app.include_router(api_router)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
       context: .
       dockerfile: Dockerfile.backend
     ports:
-      - "8000:8000"
+      - "8100:8100"
   frontend:
     build:
       context: .
       dockerfile: Dockerfile.frontend
     ports:
-      - "3000:80"
+      - "3100:80"
     depends_on:
       - backend

--- a/frontend/src/components/ApiKeyForm.tsx
+++ b/frontend/src/components/ApiKeyForm.tsx
@@ -7,7 +7,7 @@ const ApiKeyForm: React.FC<ApiKeyFormProps> = () => {
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await fetch('http://localhost:8000/apikey', {
+    await fetch('http://localhost:8100/apikey', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ api_key: key })


### PR DESCRIPTION
## Summary
- print backend startup message to console
- echo frontend startup message
- move default ports to 8100 (API) and 3100 (frontend)
- document startup messages and new ports

## Testing
- `pytest`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4d194629483238295879bc6025474